### PR TITLE
fix: override GitHub language detection to remove Hack

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,4 @@
-*.php linguist-detectable=true
+*.php linguist-language=PHP
 *.html linguist-detectable=true
 *.css linguist-detectable=true
 *.js linguist-detectable=true

--- a/README.md
+++ b/README.md
@@ -276,3 +276,4 @@ Built with 💜 by @AshiTomar210
 
 
 ---
+"Trigger Linguist refresh" 

--- a/refresh.php
+++ b/refresh.php
@@ -1,0 +1,1 @@
+"// refresh trigger" 

--- a/refresh.php
+++ b/refresh.php
@@ -1,1 +1,0 @@
-"// refresh trigger" 


### PR DESCRIPTION
This PR updates the `.gitattributes` file to correct GitHub's language detection. Hack was previously showing up in the language stats, even though no `.hack` files or Hack syntax (`<?hh`) are present in the repo.

 Changes made:
- Added `*.php linguist-language=PHP` to force PHP classification
- Verified `.hack` files are absent
- Triggered a refresh to validate the fix

Confirmed in my fork — Hack no longer appears in the sidebar.  
Resolves #26.
